### PR TITLE
Added "configurator" tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-test/
+# IDE
 .vscode/
+.idea/
+
+# local testing
+test/
 cleaner_config.yml
 dump_file.txt

--- a/configurator/configurator_test.go
+++ b/configurator/configurator_test.go
@@ -1,0 +1,99 @@
+package configurator
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v3"
+)
+
+type MockedOs struct {
+	mock.Mock
+}
+
+func (mio *MockedOs) ReadFile(filePath string) ([]byte, error) {
+	args := mio.Called(filePath)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (mio *MockedOs) Stat(filePath string) (os.FileInfo, error) {
+	args := mio.Called(filePath)
+	a0, _ := args.Get(0).(os.FileInfo)
+	return a0, args.Error(1)
+}
+
+func (mio *MockedOs) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return mio.Called(name, data, perm).Error(0)
+}
+
+func TestReadConfigurationFromFileEmpty(t *testing.T) {
+	mos := MockedOs{}
+	configFile := "someFile"
+	mos.On("ReadFile", configFile).Return([]byte{}, nil)
+	c := NewConfigurator(&mos)
+
+	conf, err := c.readConfigurationFromFile(configFile)
+
+	assert.Nil(t, err)
+	assert.Equal(t, &Configuration{}, conf)
+	mos.AssertExpectations(t)
+}
+
+func TestIsFilePresent(t *testing.T) {
+	tests := []struct {
+		inErr error
+		out   bool
+	}{
+		{nil, true},
+		{os.ErrNotExist, false},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("%v,%v", test.inErr, test.out)
+		t.Run(name, func(t *testing.T) {
+			mos := MockedOs{}
+			configFile := "someFile"
+			mos.On("Stat", configFile).Return(nil, test.inErr)
+			c := NewConfigurator(&mos)
+
+			isPresent := c.isFilePresent(configFile)
+
+			assert.Equal(t, test.out, isPresent)
+			mos.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSaveConfigurationToFile(t *testing.T) {
+	config := Configuration{
+		StartPath: "somePath",
+		RealClean: false,
+		IsReady:   false,
+		SizeConfig: SizeConfig{
+			Threshold: 2,
+			CatchZero: true,
+		},
+		Exts: Exts{
+			WhiteList: []string{"a"},
+			BlackList: []string{"b"},
+		},
+		Files: Files{
+			WhiteList: []string{"c"},
+			BlackList: []string{"d"},
+		},
+		Contents: []string{"someContent"},
+	}
+	mos := MockedOs{}
+	filePath := "someFilePath"
+	bytes, err := yaml.Marshal(config)
+	assert.Nil(t, err)
+	mos.On("WriteFile", filePath, bytes, os.FileMode(0666)).Return(nil)
+	c := NewConfigurator(&mos)
+
+	err = c.SaveConfigurationToFile(&config, filePath)
+
+	assert.Nil(t, err)
+}

--- a/configurator/os.go
+++ b/configurator/os.go
@@ -1,0 +1,23 @@
+package configurator
+
+import "os"
+
+type OsWrapper interface {
+	ReadFile(name string) ([]byte, error)
+	Stat(name string) (os.FileInfo, error)
+	WriteFile(name string, data []byte, perm os.FileMode) error
+}
+
+type BuiltInOs struct{}
+
+func (bio BuiltInOs) ReadFile(filePath string) ([]byte, error) {
+	return os.ReadFile(filePath)
+}
+
+func (bio BuiltInOs) Stat(filePath string) (os.FileInfo, error) {
+	return os.Stat(filePath)
+}
+
+func (bio BuiltInOs) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(name, data, perm)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main.go
+++ b/main.go
@@ -11,30 +11,46 @@ const dumpFilePath = "./dump_file.txt"
 
 var (
 	dumpFile *os.File
-	config   = &configurator.Config
 )
 
 func main() {
-	configurator.Init()
+	config := configurator.NewConfigurator(configurator.BuiltInOs{})
+	configuration, fileExists, err := config.GetConfiguration()
+	printErrAndExit(err)
 
-	if !config.IsReady {
-		log.Println("Not ready, check and adjust 'cleaner_config.yml' file to ger ready")
+	if !fileExists {
+		err := config.SaveConfigurationToFile(configuration, configurator.ConfigFileName)
+		printErrAndExit(err)
+
+		log.Printf("Configuration file %s with default options was created in current directory. "+
+			"Check its content, update it and rerun the command.\n", configurator.ConfigFileName)
+	}
+
+	if !configuration.IsReady {
+		log.Println("Configuraiton is not ready, adjust 'cleaner_config.yml' file to get it ready.")
 		return
 	}
 
 	createDumpFile()
 	defer dumpFile.Close()
 
-	_, err := dumpFile.WriteString(representation())
+	_, err = dumpFile.WriteString(representation())
 	if err != nil {
 		log.Println(err)
 	}
-	log.Printf("Real mode %t \n", config.RealClean)
+	log.Printf("Real mode %t \n", configuration.RealClean)
 
 	log.Println("--->> Go...")
-	checkAndRemove(config.StartPath)
+	checkAndRemove(configuration.StartPath, configuration)
 
 	log.Println("<<--- Finished")
-	printStats(config.RealClean)
+	printStats(configuration.RealClean)
 	log.Println(representation())
+}
+
+func printErrAndExit(err error) {
+	if err != nil {
+		log.Printf("Error: %s.\n", err.Error())
+		os.Exit(1)
+	}
 }

--- a/processor.go
+++ b/processor.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"go-cleaner/checker"
+	"go-cleaner/configurator"
 	"log"
 	"os"
 	"path"
 	"sort"
 )
 
-func checkAndRemove(dirPath string) error {
+func checkAndRemove(dirPath string, config *configurator.Configuration) error {
 	printPath := true
 	stats.FolderChecked++
 	entries, err := os.ReadDir(dirPath)
@@ -23,7 +24,7 @@ func checkAndRemove(dirPath string) error {
 	for _, entry := range entries {
 		fullFilePath := path.Join(dirPath, entry.Name())
 		if entry.IsDir() {
-			checkAndRemove(fullFilePath)
+			checkAndRemove(fullFilePath, config)
 			// we don't need to check error here
 			// if internal folder is absent it means that it's been deleted or renamed
 			// so we just skip this check
@@ -46,7 +47,7 @@ func checkAndRemove(dirPath string) error {
 			checker.IsContentContain(fullFilePath, config.Contents)
 
 		if isMatch {
-			catchFile(fullFilePath)
+			catchFile(fullFilePath, config)
 
 			if printPath {
 				dumpFile.WriteString(fmt.Sprintln(dirPath))
@@ -61,7 +62,7 @@ func checkAndRemove(dirPath string) error {
 	return nil
 }
 
-func catchFile(filePath string) {
+func catchFile(filePath string, config *configurator.Configuration) {
 	if config.RealClean {
 		err := os.Remove(filePath)
 		if err != nil {


### PR DESCRIPTION
I refactored the code to remove global configuration structure and introduced `OsWrapper` to make it possible to mock `os` package in tests.